### PR TITLE
Refactored to use the new imageUrl from core

### DIFF
--- a/src/Flag.vue
+++ b/src/Flag.vue
@@ -10,12 +10,12 @@
       gradient,
       className
     ]">
-    <img :src="`https://raw.githubusercontent.com/Yummygum/flag-pack-core/master/svg/${size.toLowerCase()}/${isoToCountryCodeLocal.toUpperCase()}.svg?sanitize=true`">
+    <img :src="imageUrl(isoToCountryCodeLocal.toUpperCase(), size.toLowerCase())">
   </div>
 </template>
 
 <script>
-import { isoToCountryCode } from 'flagpack-core'
+import { isoToCountryCode, imageUrl } from 'flagpack-core'
 
 export default {
   name: 'Flag',


### PR DESCRIPTION
Following [my changes on flag-pack-core](https://github.com/Yummygum/flag-pack-core/pull/5), the code now uses the new `imageUrl()` function  to get the image URL instead of a hardcoded GitHub request.